### PR TITLE
pymssql: new formula v2.1.1

### DIFF
--- a/pymssql.rb
+++ b/pymssql.rb
@@ -1,0 +1,23 @@
+class Pymssql < Formula
+  homepage "http://pymssql.org/"
+  url "https://pypi.python.org/packages/source/p/pymssql/pymssql-2.1.1.tar.gz"
+  sha1 "968a254acf5358b79ad362247984c69b2855b712"
+  head "https://github.com/pymssql/pymssql.git"
+
+  depends_on :python => :recommended
+  depends_on :python3 => :optional
+
+  depends_on "freetds"
+
+  def install
+    Language::Python.each_python(build) do |python, _version|
+      system python, *Language::Python.setup_install_args(prefix)
+    end
+  end
+
+  test do
+    Language::Python.each_python(build) do |python, _version|
+      system python, "-c", "import pymssql; print(pymssql); print(pymssql.__version__)"
+    end
+  end
+end


### PR DESCRIPTION
This adds a new formula for pymssql

- http://pymssql.org/
- https://pypi.python.org/pypi/pymssql

I've built a bottle for it on OS X 10.9.5; if there is place for me to upload it to, let me know. For now, I uploaded it to PyPI as a "dumb binary", but maybe it's better in the Homebrew sourceforge repo?

https://pypi.python.org/packages/2.7/p/pymssql/pymssql-2.1.1.mavericks.bottle.tar.gz#md5=e8c7e090a1a13fefe3675d5e3feb07d9