### PR TITLE
Diffusion Imaging in Python (DIPY)

### DIFF
--- a/dipy.rb
+++ b/dipy.rb
@@ -10,11 +10,11 @@ class Dipy < Formula
   depends_on :python => :recommended if MacOS.version <= :snow_leopard
   depends_on :python3 => :optional
   depends_on "cmake" => :build
-  depends_on "clang-omp" => :recommended
 
   numpy_options = []
   numpy_options << "with-python3" if build.with? "python3"
   depends_on "homebrew/python/numpy" => numpy_options
+  depends_on "homebrew/python/scipy" => numpy_options
   depends_on "homebrew/science/vtk" => :recommended
 
   option "without-check", "Don't run tests during installation"
@@ -39,11 +39,6 @@ class Dipy < Formula
       ENV.prepend_create_path "PYTHONPATH", lib/"python#{version}/site-packages"
       resource("nibabel").stage do
         system "python", *Language::Python.setup_install_args(prefix)
-      end
-
-      if build.with? "clang-omp"
-        ENV["CC"] = "clang-omp"
-        ENV["C_INCLUDE_PATH"]="/usr/local/include/libiomp:$C_INCLUDE_PATH"
       end
 
       system python, "setup.py", "build"

--- a/dipy.rb
+++ b/dipy.rb
@@ -15,14 +15,7 @@ class Dipy < Formula
   numpy_options = []
   numpy_options << "with-python3" if build.with? "python3"
   depends_on "homebrew/python/numpy" => numpy_options
-
-  # vtk_options = [:recommended]
-  # if build.with? "python3"
-  #   vtk_options << "with-python3" 
-  # else
-  #  vtk_options << "with-python"
-  # end
-  # depends_on "homebrew/science/vtk" => vtk_options
+  depends_on "homebrew/science/vtk" => :recommended
 
   option "without-check", "Don't run tests during installation"
 
@@ -49,6 +42,7 @@ class Dipy < Formula
 
       if build.with? "clang-omp"
         ENV["CC"] = "clang-omp"
+        ENV["C_INCLUDE_PATH"]="/usr/local/include/libiomp:$C_INCLUDE_PATH"
       end
 
       system python, "setup.py", "build"

--- a/dipy.rb
+++ b/dipy.rb
@@ -16,13 +16,13 @@ class Dipy < Formula
   numpy_options << "with-python3" if build.with? "python3"
   depends_on "homebrew/python/numpy" => numpy_options
 
-  vtk_options = [:recommended]
-  if build.with? "python3"
-    vtk_options << "with-python3" 
-  else
-   vtk_options << "with-python"
-  end
-  depends_on "homebrew/science/vtk" => vtk_options
+  # vtk_options = [:recommended]
+  # if build.with? "python3"
+  #   vtk_options << "with-python3" 
+  # else
+  #  vtk_options << "with-python"
+  # end
+  # depends_on "homebrew/science/vtk" => vtk_options
 
   option "without-check", "Don't run tests during installation"
 

--- a/dipy.rb
+++ b/dipy.rb
@@ -9,7 +9,7 @@ class Dipy < Formula
 
   depends_on :python => :recommended if MacOS.version <= :snow_leopard
   depends_on :python3 => :optional
-  depends_on :cmake => :recommended
+  depends_on "cmake" => :build
   depends_on "clang-omp" => :recommended
 
   numpy_options = []

--- a/dipy.rb
+++ b/dipy.rb
@@ -15,11 +15,19 @@ class Dipy < Formula
   numpy_options << "with-python3" if build.with? "python3"
   depends_on "homebrew/python/numpy" => numpy_options
 
+  vtk_options = ["recommended"]
+  if build.with? "python3"
+    vtk_options << "with-python3" 
+  else
+   vtk_options << "with-python"
+ end
+  depends_on "homebrew/science/vtk" => vtk_options
+
   option "without-check", "Don't run tests during installation"
 
   resource "nibabel" do
     url "https://pypi.python.org/packages/source/n/nibabel/nibabel-2.0.2.tar.gz"
-    sha256 "2d725e862b9a383db22b595e749142a6d0e181e371b245a12bd837ba9ddb"
+    sha256 "f0ccd90ccf9ff5f9a203e1d7e2f21989db0bee1db4f9cc2762db2c5e7fd9154d"
   end
 
   def install
@@ -33,14 +41,13 @@ class Dipy < Formula
 
     Language::Python.each_python(build) do |python, version|
       ENV["PYTHONPATH"] = Formula["dipy"].opt_lib/"python#{version}/site-packages"
-      ENV["CC"] = "clang-omp"
       ENV.prepend_create_path "PYTHONPATH", lib/"python#{version}/site-packages"
 
       if build.with? "clang-omp"
-        system python, "setup.py", "build"#, "--fcompiler=clang-omp"
-      else
-        system python, "setup.py", "build"
+        ENV["CC"] = "clang-omp"
       end
+
+      system python, "setup.py", "build"
       system python, *Language::Python.setup_install_args(prefix)
     end
   end

--- a/dipy.rb
+++ b/dipy.rb
@@ -31,14 +31,15 @@ class Dipy < Formula
 
   def install
     Language::Python.each_python(build) do |python, version|
-      ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
-      %w[nibabel cython].each do |r|
-        resource(r).stage do
-          system "python", *Language::Python.setup_install_args(libexec/"vendor")
-        end
+      ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python#{version}/site-packages"
+      resource("cython").stage do
+        system "python", *Language::Python.setup_install_args(libexec/"vendor")
       end
 
       ENV.prepend_create_path "PYTHONPATH", lib/"python#{version}/site-packages"
+      resource("nibabel").stage do
+        system "python", *Language::Python.setup_install_args(prefix)
+      end
 
       if build.with? "clang-omp"
         ENV["CC"] = "clang-omp"
@@ -55,5 +56,4 @@ class Dipy < Formula
       system python, "-c", "import dipy; assert dipy.test().wasSuccessful()"
     end
   end
-
 end

--- a/dipy.rb
+++ b/dipy.rb
@@ -15,12 +15,12 @@ class Dipy < Formula
   numpy_options << "with-python3" if build.with? "python3"
   depends_on "homebrew/python/numpy" => numpy_options
 
-  vtk_options = ["recommended"]
+  vtk_options = [:recommended]
   if build.with? "python3"
     vtk_options << "with-python3" 
   else
    vtk_options << "with-python"
- end
+  end
   depends_on "homebrew/science/vtk" => vtk_options
 
   option "without-check", "Don't run tests during installation"
@@ -30,10 +30,14 @@ class Dipy < Formula
     sha256 "f0ccd90ccf9ff5f9a203e1d7e2f21989db0bee1db4f9cc2762db2c5e7fd9154d"
   end
 
-  def install
+  resource "cython" do
+    url "https://pypi.python.org/packages/source/C/Cython/Cython-0.24.tar.gz"
+    sha256 "6de44d8c482128efc12334641347a9c3e5098d807dd3c69e867fa8f84ec2a3f1"
+  end
 
+  def install
     ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
-    %w[nibabel].each do |r|
+    %w[nibabel cython].each do |r|
       resource(r).stage do
         system "python", *Language::Python.setup_install_args(libexec/"vendor")
       end

--- a/dipy.rb
+++ b/dipy.rb
@@ -37,15 +37,14 @@ class Dipy < Formula
   end
 
   def install
-    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
-    %w[nibabel cython].each do |r|
-      resource(r).stage do
-        system "python", *Language::Python.setup_install_args(libexec/"vendor")
-      end
-    end
-
     Language::Python.each_python(build) do |python, version|
-      ENV["PYTHONPATH"] = Formula["dipy"].opt_lib/"python#{version}/site-packages"
+      ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
+      %w[nibabel cython].each do |r|
+        resource(r).stage do
+          system "python", *Language::Python.setup_install_args(libexec/"vendor")
+        end
+      end
+
       ENV.prepend_create_path "PYTHONPATH", lib/"python#{version}/site-packages"
 
       if build.with? "clang-omp"

--- a/dipy.rb
+++ b/dipy.rb
@@ -9,6 +9,7 @@ class Dipy < Formula
 
   depends_on :python => :recommended if MacOS.version <= :snow_leopard
   depends_on :python3 => :optional
+  depends_on :cmake => :recommended
   depends_on "clang-omp" => :recommended
 
   numpy_options = []

--- a/dipy.rb
+++ b/dipy.rb
@@ -1,0 +1,54 @@
+class Dipy < Formula
+  desc "Diffusion Imaging in Python"
+  homepage "http://dipy.org/"
+  url "https://github.com/nipy/dipy/archive/0.11.0.tar.gz"
+  sha256 "b9b7c19ccf9d5087f2bdea86478319a5355bb4d4c5cb23afd7d85b09048d1716"
+  head "https://github.com/nipy/dipy.git"
+
+  option "without-python", "Build without python2 support"
+
+  depends_on :python => :recommended if MacOS.version <= :snow_leopard
+  depends_on :python3 => :optional
+  depends_on "clang-omp" => :recommended
+
+  numpy_options = []
+  numpy_options << "with-python3" if build.with? "python3"
+  depends_on "homebrew/python/numpy" => numpy_options
+
+  option "without-check", "Don't run tests during installation"
+
+  resource "nibabel" do
+    url "https://pypi.python.org/packages/source/n/nibabel/nibabel-2.0.2.tar.gz"
+    sha256 "2d725e862b9a383db22b595e749142a6d0e181e371b245a12bd837ba9ddb"
+  end
+
+  def install
+
+    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
+    %w[nibabel].each do |r|
+      resource(r).stage do
+        system "python", *Language::Python.setup_install_args(libexec/"vendor")
+      end
+    end
+
+    Language::Python.each_python(build) do |python, version|
+      ENV["PYTHONPATH"] = Formula["dipy"].opt_lib/"python#{version}/site-packages"
+      ENV["CC"] = "clang-omp"
+      ENV.prepend_create_path "PYTHONPATH", lib/"python#{version}/site-packages"
+
+      if build.with? "clang-omp"
+        system python, "setup.py", "build"#, "--fcompiler=clang-omp"
+      else
+        system python, "setup.py", "build"
+      end
+      system python, *Language::Python.setup_install_args(prefix)
+    end
+  end
+
+  test do
+    Language::Python.each_python(build) do |python, _version|
+      system python, "-c", "import dipy; assert dipy.test().wasSuccessful()"
+    end
+  end
+
+end


### PR DESCRIPTION
This PR adds the installation for DIPY (https://github.com/nipy/dipy)

Dependencies:
- Python
- Numpy
- Nibabel
- Clang-OMP (to compile Cython with multithreading, recommended)
- VTK (with Python, recommended)
- Cython

For testing:
`brew install stephanmeesters/python/dipy`
