### PR TITLE
Fix pyrit formula

### DIFF
--- a/pyrit.rb
+++ b/pyrit.rb
@@ -1,8 +1,8 @@
 class Pyrit < Formula
   desc "Attack against WPA-PSK authentication"
-  homepage "https://code.google.com/p/pyrit/"
-  url "https://pyrit.googlecode.com/files/pyrit-0.4.0.tar.gz"
-  sha256 "eb1a21cb844b1ded3eab613a8e9d5e4ef901530b04668fb18fe82ed1b4afa7cc"
+  homepage "https://github.com/JPaulMora/Pyrit"
+  url "https://github.com/JPaulMora/Pyrit/archive/v0.5.0.tar.gz"
+  sha256 "c610b7e5930e71ef466365418e58ce72f4b7dea5a3398c3296192f0c4a7175aa"
 
   bottle do
     sha256 "988ba5e46df34c95ebf72294a146338ade7e3972d82ca76f1182f720717bf417" => :yosemite


### PR DESCRIPTION
1) pyrit was migrated from Google Code hosting to GitHub
2) Updated to the latest version 0.5.0

Closes bug #348