### PR TITLE
Fix a typo in matplotlib's dependency.

### DIFF
--- a/matplotlib.rb
+++ b/matplotlib.rb
@@ -1,6 +1,6 @@
 class DvipngRequirement < Requirement
   fatal false
-  cask "matctex"
+  cask "mactex"
 
   satisfy { which("dvipng") }
 


### PR DESCRIPTION
matctex => mactex.